### PR TITLE
Add the game manifest test coverage

### DIFF
--- a/electron/launcher/manifest.ts
+++ b/electron/launcher/manifest.ts
@@ -112,3 +112,7 @@ export async function resolveManifest() {
 
   return globalManifestSearchEngine;
 }
+
+export async function resetManifestCache() {
+  globalManifestSearchEngine = undefined;
+}

--- a/electron/launcher/test/manifest.spec.ts
+++ b/electron/launcher/test/manifest.spec.ts
@@ -82,6 +82,15 @@ describe("Version manifest with no parent path exist", function () {
     resetManifestCache();
   });
 
+  after(() => {
+    // Make a directory after executed tests
+    if (!fse.existsSync(getVersionsPath())) {
+      fse.mkdirSync(getVersionsPath());
+    }
+    expect(fse.existsSync(getVersionsPath())).to.be.true;
+    resetManifestCache();
+  });
+
   it(`should throw error when resolve without parent`, function () {
     return resolveManifest()
       .then(() => {})

--- a/electron/launcher/test/manifest.spec.ts
+++ b/electron/launcher/test/manifest.spec.ts
@@ -1,20 +1,24 @@
 import { expect } from "chai";
 import fse from "fs-extra";
 import path from "path";
-import { resolveManifest } from "../manifest";
+import { resetManifestCache, resolveManifest } from "../manifest";
 import { getVersionsPath } from "../versions";
 
-describe("Version manifest ", function () {
+describe("Version manifest with existed parent", function () {
   /**
    * The resolve function may be slow since it is fetching from server.
    */
-  this.slow();
+  this.timeout(10000);
 
   before(() => {
     // Make a directory before executing tests
     if (!fse.existsSync(getVersionsPath())) {
       fse.mkdirSync(getVersionsPath());
     }
+  });
+
+  after(async () => {
+    await resetManifestCache();
   });
 
   it(`should resolve from nothing (no cache existed)`, function (done) {
@@ -40,20 +44,49 @@ describe("Version manifest ", function () {
       .catch(done);
   });
 
-  it(`should throw error when resolve without parent`, function (done) {
+  it(`should using from cache (global manifest)`, () => {
+    return resolveManifest().then((searchEngine) => {
+      expect(searchEngine.get(searchEngine.getLatestRelease())).not.to.be
+        .undefined;
+      expect(searchEngine.get(searchEngine.getLatestSnapshot())).not.to.be
+        .undefined;
+
+      // Some major Minecraft version test
+      const assertionMajorVersionList = ["1.7", "1.8", "1.9", "1.10", "1.11"];
+      expect(
+        assertionMajorVersionList
+          .map((version) => {
+            return searchEngine.has(version);
+          })
+          .every((value) => value)
+      ).to.be.true;
+    });
+  });
+});
+
+describe("Version manifest with no parent path exist", function () {
+  /**
+   * The resolve function may be slow since it is fetching from server.
+   */
+  this.timeout(10000);
+
+  before(() => {
     // Trying to remove the path
     if (fse.existsSync(getVersionsPath())) {
-      fse.removeSync(getVersionsPath());
+      fse.emptyDir(getVersionsPath());
+      fse.rmdirSync(getVersionsPath(), { recursive: true });
     }
 
-    resolveManifest().catch((err) => {
-      expect(err.message).to.be.match(/Unable to load parent directory+/);
+    expect(fse.existsSync(getVersionsPath())).to.be.false;
 
-      // Then , remake a directory
-      if (!fse.existsSync(getVersionsPath())) {
-        fse.mkdirSync(getVersionsPath());
-      }
-      done();
-    });
+    resetManifestCache();
+  });
+
+  it(`should throw error when resolve without parent`, function () {
+    return resolveManifest()
+      .then(() => {})
+      .catch((err) => {
+        expect(err.message).to.includes("Unable to load");
+      });
   });
 });


### PR DESCRIPTION
## Describe your changes
- Add more test coverage for `manifest.ts`
### Tests

- `manifest.spec.ts`:
  - request large time-out to resolve version manifest file
  - reset manifest global cache after test loaded
  - add test for throwing when the parent is not defined or existed

## Flight-check

- [x] All tests are passed
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
