### PR TITLE
add: `profile.ts`

### DIFF
--- a/electron/index.ts
+++ b/electron/index.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { isProduction } from "./environment";
 import { getLauncherAppPath, setupUserDataPath } from "./launcher/file";
 import { resolveManifest } from "./launcher/manifest";
+import { loadGlobalProfileStorage, ProfileManager, ProfileStorage } from "./launcher/profile";
 import {
   getSettingsConfiguration,
   hasSettingsFile,
@@ -92,6 +93,13 @@ app.on("window-all-closed", () => {
   console.log(
     `Latest release minecraft version now is ${searchEngine.getLatestRelease()}`
   );
+  loadingWindow.webContents.send("loading:message", {
+    message: "loading profiles",
+  });
+  
+  // Load profile if not exists
+  ProfileManager.setupDefaultProfile()
+  loadGlobalProfileStorage()
 
   loadingWindow.webContents.send("loading:message", {
     message: "loading launcher configuration",

--- a/electron/launcher/manifest.ts
+++ b/electron/launcher/manifest.ts
@@ -3,7 +3,7 @@ import needle from "needle";
 import path from "path";
 import { getVersionsPath } from "./versions";
 
-export type MinecraftSemver = string;
+export type MinecraftSemver = string | "latest" | "latest_snapshot";
 
 export interface ManifestLatest {
   release: MinecraftSemver;
@@ -110,6 +110,10 @@ export async function resolveManifest() {
   console.log(`Caching the manifest search engine into memory`);
   globalManifestSearchEngine = new ManifestSearchEngine(manifestResponse);
 
+  return globalManifestSearchEngine;
+}
+
+export function getGlobalManifest() {
   return globalManifestSearchEngine;
 }
 

--- a/electron/launcher/profile.ts
+++ b/electron/launcher/profile.ts
@@ -237,3 +237,14 @@ export class ProfileStorage {
     return { items };
   }
 }
+
+let globalProfileStorage: ProfileStorage | undefined;
+
+export function loadGlobalProfileStorage() {
+  const launcherProfile = ProfileManager.getProfileFromFile();
+  globalProfileStorage = new ProfileStorage(launcherProfile);
+}
+
+export function getGlobalProfileStorage() {
+  return globalProfileStorage;
+}

--- a/electron/launcher/profile.ts
+++ b/electron/launcher/profile.ts
@@ -1,0 +1,239 @@
+import { v4 } from "uuid";
+import { JsonDuplex } from "./../file/JsonDuplex";
+import fse from "fs-extra";
+import {
+  getGlobalManifest,
+  ManifestSearchEngine,
+  MinecraftSemver,
+} from "./manifest";
+import path from "path";
+import { getLauncherAppPath } from "./file";
+
+/**
+ * Get a profile file name.
+ *
+ * @returns a profile file name
+ */
+export function getProfileFileName() {
+  return path.join(getLauncherAppPath(), "profiles.json");
+}
+
+export interface ProfileItem {
+  /**
+   * A unique id (UUID) of the items
+   */
+  uid: string;
+  name: string;
+  minecraftVersion: MinecraftSemver;
+}
+
+export interface LauncherProfile {
+  items: ProfileItem[];
+}
+
+export function hasProfileFile() {
+  return fse.existsSync(getProfileFileName());
+}
+
+export class ProfileManager {
+  private static duplex: JsonDuplex<LauncherProfile> = new JsonDuplex(
+    getProfileFileName()
+  );
+
+  constructor() {}
+
+  /**
+   * Test whether or not the duplex file (profile file name) is existed.
+   * @returns true if the profile file was created, false otherwise.
+   */
+  public static isExistProfileFile() {
+    return this.duplex.hasFile();
+  }
+
+  /**
+   * Create a profile as default settings if the file is not existed.
+   *
+   * Silently do nothing if the file was existed.
+   */
+  public static setupDefaultProfile() {
+    // Make a file as default file if the file was not existed
+    if (!this.isExistProfileFile()) {
+      const profile: LauncherProfile = {
+        items: [
+          {
+            uid: v4(),
+            name: "Latest",
+            minecraftVersion: "latest",
+          },
+        ],
+      };
+
+      console.log(`Writing default profile version `);
+      // Store the object above onto disk as json file
+      fse.writeJsonSync(getProfileFileName(), profile);
+    }
+  }
+
+  /**
+   * Get the launcher profile which stored from file.
+   *
+   * @returns a launcher profile from stored file
+   * @throws if the profile file is not existed
+   */
+  public static getProfileFromFile() {
+    if (!this.isExistProfileFile()) {
+      throw new Error(
+        "The profile file is not existed, should run setupDefaultProfile to generate a default profile."
+      );
+    }
+    return fse.readJsonSync(getProfileFileName()) as LauncherProfile;
+  }
+
+  /**
+   * Write a launcher profile into disk.
+   *
+   * @param launcherProfile a launcher profile to store into a file
+   */
+  public static storeProfile(launcherProfile: LauncherProfile) {
+    fse.writeJsonSync(getProfileFileName(), launcherProfile);
+  }
+}
+
+export class ProfileStorage {
+  private profileMap: Map<string, ProfileItem> = new Map();
+  private globalManifest: ManifestSearchEngine;
+  constructor(profile: LauncherProfile) {
+    const _globManifest = getGlobalManifest();
+    if (!_globManifest) {
+      throw new Error(
+        `Global manifest has not loaded. Should call resolveManifest before load profile storage.`
+      );
+    }
+
+    this.globalManifest = _globManifest;
+
+    if (!profile) {
+      throw new Error("Profile cannot be undefined.");
+    }
+
+    for (const profileItem of profile.items) {
+      const profileItemParsed = {
+        ...profileItem,
+        minecraftVersion:
+          profileItem.minecraftVersion === "latest"
+            ? // If the minecraftVersion field was latest, get latest release from manifest
+              this.globalManifest?.getLatestRelease()
+            : //Otherwise, if the minecraftVersion was latest snapshot, get latest snapshot from manifest
+            profileItem.minecraftVersion === "latest_snapshot"
+            ? this.globalManifest?.getLatestSnapshot()
+            : // Or using the minecraftVersion from data
+              profileItem.minecraftVersion,
+      };
+
+      //  Test the minecraft version id
+      this.assertMinecraftVersion(profileItemParsed.minecraftVersion);
+
+      this.profileMap.set(profileItem.uid, profileItemParsed);
+    }
+  }
+
+  private assertMinecraftVersion(version: MinecraftSemver, message?: string) {
+    if (!this.globalManifest.has(version)) {
+      throw new Error(message || `Invalid minecraft version ${version}`);
+    }
+  }
+
+  /**
+   * Get all profile items contains inside profile map.
+   *
+   * @returns a new array from profile map value entries
+   */
+  public getAllProfileItems(): ProfileItem[] {
+    return Array.from(this.profileMap.values());
+  }
+
+  /**
+   * Get a profile from it uid, the profile could be undefined.
+   *
+   * @param uid a profile uid to get
+   * @returns a profile item if exists, undefined otherwise.
+   */
+  public getProfileFromUid(uid: string): ProfileItem | undefined {
+    return this.profileMap.get(uid);
+  }
+
+  /**
+   * Get a list of profile what match with the provided minecraft version parameter.
+   * Using the linear search algorithm to iterate all over the profile map value entries.
+   *
+   * @param minecraftVersion a minecraft version to search
+   * @returns a list of ProfileItem, which match with the minecraftVersion
+   */
+  public getProfileFromMinecraftVersion(
+    minecraftVersion: MinecraftSemver
+  ): ProfileItem[] {
+    const response = [];
+    for (const item of this.profileMap.values()) {
+      if (item.minecraftVersion === minecraftVersion) {
+        response.push(item);
+      }
+    }
+    return response;
+  }
+
+  /**
+   * Add profile item into storage map. If a provided item
+   * contains non-existed minecraft version which assert from
+   * version manifest, throws an Error.
+   *
+   * @param item a profile item to add into storage
+   */
+  public createProfileItem(item: ProfileItem) {
+    this.assertMinecraftVersion(item.minecraftVersion);
+    if (item.name === undefined) {
+      throw new Error(`Profile name cannot be undefined`);
+    }
+
+    if (item.uid === undefined) {
+      throw new Error(`Profile uid cannot be undefined`);
+    }
+
+    if (this.getProfileFromUid(item.uid) !== undefined) {
+      throw new Error(`Uid conflict ${item.uid}`);
+    }
+
+    this.profileMap.set(item.uid, item);
+  }
+
+  /**
+   * Remove a profile with uid out of storage map.
+   * If the uid has not existed, throws an Error.
+   *
+   * @param uid a profile uid to remove
+   */
+  public removeProfileItem(uid: string) {
+    if (!this.getProfileFromUid(uid)) {
+      throw new Error(`Profile with uid ${uid} not found.`);
+    }
+
+    this.profileMap.delete(uid);
+  }
+
+  /**
+   * Turns a profile map into launcher profile object by iterating
+   * over the profile value and construct an item array, then return
+   * with a LauncherProfile interface.
+   *
+   * NOTE: return an object, not a json string.
+   *
+   * @returns a launcher profile contains all items from profile map
+   */
+  public toLauncherProfile(): LauncherProfile {
+    const items = [];
+    for (const item of this.profileMap.values()) {
+      items.push(item);
+    }
+
+    return { items };
+  }
+}

--- a/electron/launcher/test/profile.spec.ts
+++ b/electron/launcher/test/profile.spec.ts
@@ -1,0 +1,283 @@
+import { LauncherProfile, ProfileManager, ProfileStorage } from "./../profile";
+import { expect } from "chai";
+import { getProfileFileName, hasProfileFile } from "../profile";
+import fse from "fs-extra";
+import { v4 } from "uuid";
+import {
+  getGlobalManifest,
+  getManifestFileName,
+  resolveManifest,
+} from "../manifest";
+
+describe("ProfileManager ", () => {
+  afterEach(() => {
+    // Clean the path for other test
+    if (fse.existsSync(getProfileFileName())) {
+      fse.removeSync(getProfileFileName());
+    }
+    expect(fse.existsSync(getProfileFileName())).to.be.false;
+  });
+
+  it("should throw exception wisely", () => {
+    expect(() => {
+      ProfileManager.getProfileFromFile();
+    }).to.throws(
+      "The profile file is not existed, should run setupDefaultProfile to generate a default profile."
+    );
+  });
+
+  it("should make profiles.json when setup", () => {
+    expect(getProfileFileName()).to.includes("profiles.json");
+    expect(hasProfileFile()).to.be.false;
+
+    expect(() => {
+      ProfileManager.setupDefaultProfile();
+    }).to.not.throw();
+
+    expect(hasProfileFile()).to.be.true;
+
+    // Assert the profile getter, response a launcher profile object
+    const defaultProfileData = ProfileManager.getProfileFromFile();
+    expect(defaultProfileData).to.have.property(`items`);
+    expect(Array.isArray(defaultProfileData.items));
+    expect(defaultProfileData.items.length).to.be.eq(1);
+
+    // Assert the default profile setup
+    const defaultProfileItem = defaultProfileData.items[0];
+    expect(defaultProfileItem.name).to.be.eq("Latest");
+    expect(defaultProfileItem.minecraftVersion).to.be.eq("latest");
+
+    // Assert save function
+    defaultProfileData.items.push({
+      uid: v4(),
+      name: "1.12.2",
+      minecraftVersion: "1.12.2",
+    });
+    ProfileManager.storeProfile(defaultProfileData);
+    const afterUpdateProfileData = ProfileManager.getProfileFromFile();
+    expect(afterUpdateProfileData).to.have.property(`items`);
+    expect(Array.isArray(afterUpdateProfileData.items));
+    expect(afterUpdateProfileData.items.length).to.be.eq(2);
+
+    expect(afterUpdateProfileData.items[0].name).to.eq("Latest");
+    expect(afterUpdateProfileData.items[0].minecraftVersion).to.eq("latest");
+
+    expect(afterUpdateProfileData.items[1].name).to.eq("1.12.2");
+    expect(afterUpdateProfileData.items[1].minecraftVersion).to.eq("1.12.2");
+  });
+});
+
+describe("ProfileStorage", () => {
+  describe(`Not setup version manifest yet`, () => {
+    it(`should throw exception when construct ProfileStorage`, () => {
+      ProfileManager.setupDefaultProfile();
+      const launcherProfile = ProfileManager.getProfileFromFile();
+      expect(launcherProfile).not.to.be.undefined;
+
+      // Assertion throws when construct new profile storage without version manifest loaded
+      expect(() => {
+        new ProfileStorage(launcherProfile);
+      }).to.throws(
+        `Global manifest has not loaded. Should call resolveManifest before load profile storage.`
+      );
+    });
+  });
+
+  describe(`Set up version manifest`, () => {
+    before((done) => {
+      // Setup the version manifest for profile test
+      resolveManifest()
+        .then(() => {
+          expect(fse.existsSync(getManifestFileName())).to.be.true;
+          done();
+        })
+        .catch(done);
+    });
+
+    it(`should throw exception when construct undefined parameter ProfileStorage`, () => {
+      expect(() => {
+        new ProfileStorage(undefined as unknown as LauncherProfile);
+      }).to.throws(`Profile cannot be undefined.`);
+    });
+
+    it(`should throw when not found compatible minecraft version for profile item`, () => {
+      ProfileManager.setupDefaultProfile();
+      ProfileManager.getProfileFromFile();
+
+      expect(() => {
+        new ProfileStorage({
+          items: [
+            {
+              name: "latest",
+              minecraftVersion: "non-exist-version",
+              uid: v4(),
+            },
+          ],
+        });
+      }).to.throws(/Invalid minecraft version.+/);
+    });
+
+    it(`should fill profile storage with compatible version from MinecraftSemver`, () => {
+      ProfileManager.setupDefaultProfile();
+      const launcherProfile = ProfileManager.getProfileFromFile();
+      const profileStorage = new ProfileStorage(launcherProfile);
+
+      // Assert profile response from storage
+      const profileItemList = profileStorage.getAllProfileItems();
+      expect(Array.isArray(profileItemList)).to.be.true;
+      expect(profileItemList.length).to.be.eq(1);
+
+      const latestMinecraftVersion = getGlobalManifest()?.getLatestRelease();
+
+      // Assert the generated default profile item
+      const defaultProfileItem = profileItemList[0];
+      expect(defaultProfileItem.minecraftVersion).to.be.eq(
+        latestMinecraftVersion
+      );
+
+      // Assert existing on the profile map
+      expect(profileStorage.getProfileFromUid(defaultProfileItem.uid)).to.be.eq(
+        defaultProfileItem
+      );
+
+      // Assert undefined returns for profile map getter
+      expect(profileStorage.getProfileFromUid("non-exist-profile-uid")).to.be
+        .undefined;
+
+      // Assert for get profile from the minecraft version
+      const fromMinecraftVersion =
+        profileStorage.getProfileFromMinecraftVersion(
+          latestMinecraftVersion as string
+        );
+
+      expect(Array.isArray(fromMinecraftVersion)).to.be.true;
+      expect(fromMinecraftVersion.length).to.eq(1);
+      expect(defaultProfileItem.uid).to.eq(fromMinecraftVersion[0].uid);
+
+      // Assert to launcher profile
+      const toLauncherProfileObject = profileStorage.toLauncherProfile();
+      expect(toLauncherProfileObject).to.have.property("items");
+      expect(Array.isArray(toLauncherProfileObject.items)).to.be.true;
+      expect(toLauncherProfileObject.items.length).to.be.eq(1);
+      expect(toLauncherProfileObject.items[0].uid).to.be.eq(
+        defaultProfileItem.uid
+      );
+    });
+
+    it(`should create new profile and delete it`, () => {
+      ProfileManager.setupDefaultProfile();
+      const launcherProfile = ProfileManager.getProfileFromFile();
+      const profileStorage = new ProfileStorage(launcherProfile);
+
+      const latestMinecraftVersion =
+        getGlobalManifest()?.getLatestRelease() as string;
+      const profileGeneratedUid = v4();
+      expect(() => {
+        profileStorage.createProfileItem({
+          minecraftVersion: latestMinecraftVersion,
+          uid: profileGeneratedUid,
+          name: "Second Latest Profile",
+        });
+      }).not.to.throws();
+
+      const lastInsertProfile =
+        profileStorage.getProfileFromUid(profileGeneratedUid);
+      expect(lastInsertProfile).to.not.be.undefined;
+      expect(profileStorage.toLauncherProfile().items.length).to.be.eq(2);
+
+      // Remove assertion
+      expect(() => {
+        profileStorage.removeProfileItem(
+          lastInsertProfile?.uid as unknown as string
+        );
+      }).not.to.throws(/Profile with uid.+/);
+
+      expect(profileStorage.getAllProfileItems().length).to.be.eq(1);
+    });
+
+    it(`should throw exception on create or delete function`, () => {
+      ProfileManager.setupDefaultProfile();
+      const launcherProfile = ProfileManager.getProfileFromFile();
+      const profileStorage = new ProfileStorage(launcherProfile);
+      const conflictUid = profileStorage.getAllProfileItems()[0].uid;
+      expect(() => {
+        profileStorage.createProfileItem({
+          minecraftVersion: "non-exist-mc-version",
+          uid: v4(),
+          name: "Second Latest Profile",
+        });
+      }).to.throws(/Invalid minecraft version.+/);
+
+      const latestMinecraftVersion =
+        getGlobalManifest()?.getLatestRelease() as string;
+      expect(() => {
+        profileStorage.createProfileItem({
+          minecraftVersion: latestMinecraftVersion,
+          uid: v4(),
+          name: undefined as unknown as string,
+        });
+      }).to.throws(/Profile name cannot be undefined/);
+
+      expect(() => {
+        profileStorage.createProfileItem({
+          minecraftVersion: latestMinecraftVersion,
+          uid: undefined as unknown as string,
+          name: "Other latest #1",
+        });
+      }).to.throws(/Profile uid cannot be undefined/);
+
+      expect(() => {
+        profileStorage.createProfileItem({
+          minecraftVersion: latestMinecraftVersion,
+          uid: conflictUid,
+          name: "Other latest #2",
+        });
+      }).to.throws(/Uid conflict/);
+
+      // Remove undefined uid
+      expect(() => {
+        profileStorage.removeProfileItem(v4());
+      }).to.throws(/Profile with uid.+/);
+    });
+
+    it(`should parse latest release /latest snapshot`, () => {
+      const latestReleaseMinecraftVersion =
+        getGlobalManifest()?.getLatestRelease() as string;
+
+      const latestSnapshotMinecraftVersion =
+        getGlobalManifest()?.getLatestSnapshot() as string;
+
+      const releaseProfileItemUid = v4();
+      const releaseProfileStorage = new ProfileStorage({
+        items: [
+          {
+            name: "Latest release",
+            minecraftVersion: "latest",
+            uid: releaseProfileItemUid,
+          },
+        ],
+      });
+
+      expect(
+        releaseProfileStorage.getProfileFromUid(releaseProfileItemUid)
+          ?.minecraftVersion
+      ).to.eq(latestReleaseMinecraftVersion);
+
+      const snapshotProfileItemUid = v4();
+      const snapshotProfileStorage = new ProfileStorage({
+        items: [
+          {
+            name: "Latest snapshot release",
+            minecraftVersion: "latest_snapshot",
+            uid: snapshotProfileItemUid,
+          },
+        ],
+      });
+
+      expect(
+        snapshotProfileStorage.getProfileFromUid(snapshotProfileItemUid)
+          ?.minecraftVersion
+      ).to.eq(latestSnapshotMinecraftVersion);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^4.1.2",
+        "cross-env": "^7.0.3",
         "electron-log": "^5.0.0-beta.16",
         "electron-squirrel-startup": "^1.0.0",
         "fs-extra": "^11.1.0",
-        "needle": "^3.2.0"
+        "needle": "^3.2.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@electron-forge/cli": "^6.0.4",
@@ -32,10 +35,9 @@
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "@types/uuid": "^9.0.0",
         "chai": "^4.3.7",
-        "chalk": "^4.1.2",
         "concurrently": "^7.6.0",
-        "cross-env": "^7.0.3",
         "daisyui": "^2.49.0",
         "dotenv": "^16.0.3",
         "electron": "^22.1.0",
@@ -3680,6 +3682,12 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
@@ -3843,7 +3851,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4423,7 +4430,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4596,7 +4602,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4607,8 +4612,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-string": {
       "version": "1.9.1",
@@ -4757,7 +4761,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },
@@ -4775,7 +4778,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6849,7 +6851,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7353,8 +7354,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -7407,6 +7407,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -9385,7 +9394,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10415,7 +10423,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -10427,7 +10434,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10761,7 +10767,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11341,10 +11346,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -11419,7 +11423,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -14277,6 +14280,12 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
+    },
     "@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
@@ -14399,7 +14408,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -14811,7 +14819,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -14928,7 +14935,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -14936,8 +14942,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
       "version": "1.9.1",
@@ -15057,7 +15062,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
       }
@@ -15066,7 +15070,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -16616,8 +16619,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -16955,8 +16957,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -16997,6 +16998,14 @@
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -18440,8 +18449,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -19170,7 +19178,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -19178,8 +19185,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
       "version": "1.8.0",
@@ -19447,7 +19453,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -19881,10 +19886,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -19950,7 +19954,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/uuid": "^9.0.0",
     "chai": "^4.3.7",
     "concurrently": "^7.6.0",
     "daisyui": "^2.49.0",
@@ -63,11 +64,12 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
+    "chalk": "^4.1.2",
+    "cross-env": "^7.0.3",
     "electron-log": "^5.0.0-beta.16",
     "electron-squirrel-startup": "^1.0.0",
     "fs-extra": "^11.1.0",
     "needle": "^3.2.0",
-    "cross-env": "^7.0.3",
-    "chalk": "^4.1.2"
+    "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Describe your changes
Profile store properties to instruct the launcher which version of Minecraft to run when users click Launch button

There are 3 properties for `ProfileItem`:
- **uid**: a unique id to determine which profile is it
- **minecraftVersion**: is can either be
  -  Generic Minecraft Version (`1.19`, `1.19.2`,...)
  - `latest`: get the latest version from `version_manifest_v2.json`
  - `latest_snapshot`: get the latest snapshot version from `version_manifest_v2.json`
  - **NOTE**: the version **must** exist inside the `version_manifest_v2.json`.
- **name**: a display name to a render process

`ProfileStorage`: store the profile inside a hash map which uid as a key, and `ProfileItem` as a value.

### Dependencies

- `uuid`: generate a uid for the launcher profile item

### Tests

- Test for setup the profile
- Test for parsing profile

## Flight-check

- [x] All tests are passed
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
